### PR TITLE
feat(ci): Validate release-notes for PRs

### DIFF
--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -1,0 +1,18 @@
+name: Validate release-notes from PRs
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-release-notes:
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@master
+    permissions:
+      pull-requests: read
+    with:
+      pull-request-body: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
**How to categorize this PR?**

/area open-source
/kind test

**What this PR does / why we need it**:
Introduces a workflow which runs on PRs to validate release-notes from PR text.
Please see [release-notes documentation](https://gardener.github.io/cc-utils/release_notes.html) for details.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
```other developer
NONE
```